### PR TITLE
Fix tagline punctuation consistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>3D Easy – Você imagina, a gente imprime</title>
+  <title>3D Easy – Você imagina, a gente imprime.</title>
   <style>
     body {
       margin: 0;


### PR DESCRIPTION
## Summary
- align tagline punctuation in the document title and header paragraph

## Testing
- `grep -n "Você imagina" -n index.html`


------
https://chatgpt.com/codex/tasks/task_e_68868f234e1c832aba660df0176e2bae